### PR TITLE
feat: support both next.js routers

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -21,13 +21,18 @@ async function fileExists(filePath: string): Promise<boolean> {
 }
 
 async function detectNextJsConfig(rootDir: string): Promise<{ router: 'app' | 'pages' } | null> {
-  const appRouterPath = path.join(rootDir, 'app');
-  const pagesRouterPath = path.join(rootDir, 'pages');
+  const routerCandidates: { router: 'app' | 'pages'; paths: string[] }[] = [
+    { router: 'app', paths: ['app', path.join('src', 'app')] },
+    { router: 'pages', paths: ['pages', path.join('src', 'pages')] },
+  ];
 
-  if (await fileExists(appRouterPath)) {
-    return { router: 'app' };
-  } else if (await fileExists(pagesRouterPath)) {
-    return { router: 'pages' };
+  for (const candidate of routerCandidates) {
+    for (const relativePath of candidate.paths) {
+      const absolutePath = path.join(rootDir, relativePath);
+      if (await fileExists(absolutePath)) {
+        return { router: candidate.router };
+      }
+    }
   }
 
   return null;

--- a/packages/cli/src/commands/page.ts
+++ b/packages/cli/src/commands/page.ts
@@ -26,14 +26,14 @@ page.command("create")
     try {
       console.log(`Creating new landing page: ${pagePath}`);
 
-      const pagesRootDir = await resolveRouterPath();
+      const { rootDir: pagesRootDir, pageFileName } = await resolveRouterPath();
       const fullPagePath = path.join(pagesRootDir, pagePath);
 
       console.log(`Creating directory: ${fullPagePath}`);
       await fs.mkdir(fullPagePath, { recursive: true });
 
       const code = getTemplatePageCode(DEFAULT_SEGMENTS);
-      const pageFilePath = path.join(fullPagePath, 'page.tsx');
+      const pageFilePath = path.join(fullPagePath, pageFileName);
       console.log(`Writing page file: ${pageFilePath}`);
       await fs.writeFile(pageFilePath, code);
 
@@ -66,7 +66,7 @@ page.command("add")
     try {
       console.log(`Adding segment '${segmentFile}' to page '${pagePath}'`);
 
-      const pagesRootDir = await resolveRouterPath();
+      const { rootDir: pagesRootDir, pageFileName } = await resolveRouterPath();
       const fullPagePath = path.join(pagesRootDir, pagePath);
 
       // Check if the page exists
@@ -87,7 +87,7 @@ page.command("add")
       await fs.copyFile(sourceFile, destFile);
 
       // Update page.tsx to include the new segment
-      const pageFilePath = path.join(fullPagePath, 'page.tsx');
+      const pageFilePath = path.join(fullPagePath, pageFileName);
       let pageContent = await fs.readFile(pageFilePath, 'utf-8');
       
       // Add import statement if not already present

--- a/packages/cli/src/utils/get-config.ts
+++ b/packages/cli/src/utils/get-config.ts
@@ -1,7 +1,20 @@
 import path from "path";
 import fs from "fs/promises";
 
-export async function resolveRouterPath() {
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function resolveRouterPath(): Promise<{
+  rootDir: string;
+  routerType: 'app' | 'pages';
+  pageFileName: 'page.tsx' | 'index.tsx';
+}> {
   const __dirname = process.cwd();
   let srcDir = "./";
   let config;
@@ -34,11 +47,38 @@ export async function resolveRouterPath() {
   }
 
   // Resolve the router path
-  if (!config?.nextjs?.router) {
+  const routerType = config?.nextjs?.router as 'app' | 'pages' | undefined;
+
+  if (!routerType) {
     throw new Error("Next.js router configuration not found in landing-pages.json");
   }
 
-  return path.resolve(__dirname, srcDir, config.nextjs.router);
+  const candidateDirs = [
+    path.resolve(__dirname, routerType),
+    path.resolve(__dirname, 'src', routerType),
+    path.resolve(__dirname, srcDir, routerType)
+  ];
+
+  let routerRootDir: string | undefined;
+
+  for (const candidate of candidateDirs) {
+    if (await pathExists(candidate)) {
+      routerRootDir = candidate;
+      break;
+    }
+  }
+
+  if (!routerRootDir) {
+    throw new Error(`Unable to locate Next.js ${routerType} directory. Checked: ${candidateDirs.join(', ')}`);
+  }
+
+  const pageFileName = routerType === 'app' ? 'page.tsx' : 'index.tsx';
+
+  return {
+    rootDir: routerRootDir,
+    routerType,
+    pageFileName
+  };
 }
 
 interface TsConfig {

--- a/packages/cli/src/utils/install-deps.ts
+++ b/packages/cli/src/utils/install-deps.ts
@@ -44,7 +44,7 @@ export async function installSegmentDeps(segment: string) {
 
   // Resolve aliases and paths
   const aliases = await resolveAliasesPath();
-  const routerPath = await resolveRouterPath();
+  const { rootDir: routerRootDir } = await resolveRouterPath();
 
   // Assuming 'components' is a key in the aliases object
   const componentsPath = aliases['components'] || path.join(process.cwd(), 'components');
@@ -58,7 +58,7 @@ export async function installSegmentDeps(segment: string) {
     } else if (component.source === "convertfast") {
       await copyConvertUiComponent(
         component.file,
-        path.join(routerPath, '..', 'components'),
+        path.join(routerRootDir, '..', 'components'),
         componentsPath
       );
     } else {


### PR DESCRIPTION
## Summary
- detect Next.js router directories in both root and src locations during CLI init
- expose router metadata to page creation commands to write the appropriate page file
- update dependency installer to leverage the resolved router directory

## Testing
- npx tsup

------
https://chatgpt.com/codex/tasks/task_e_68de1df3c96083228f0cc9652858f0bd